### PR TITLE
Improve resilience against ChromeDriver timeout errors

### DIFF
--- a/.github/workflows/selenium_action.yaml
+++ b/.github/workflows/selenium_action.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
       - name: Set up Python

--- a/.github/workflows/selenium_action.yaml
+++ b/.github/workflows/selenium_action.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   scrape:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
@@ -31,10 +32,21 @@ jobs:
         run: |
           sudo apt-get install fonts-ipafont fonts-ipaexfont
 
-      - name: Running the Python script
-        run: |
-          ./fetch_vangohan.py -o docs
-          ./fetch_vangohan.py -o docs -l en
+      - name: Running the Python script (Japanese)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ./fetch_vangohan.py -o docs
+
+      - name: Running the Python script (English)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ./fetch_vangohan.py -o docs -l en
 
       - name: Commit and Push The Results From Python Selenium Action
         if: github.ref == 'refs/heads/main'

--- a/fetch_vangohan.py
+++ b/fetch_vangohan.py
@@ -106,6 +106,16 @@ class VangohanScraper:
         except Exception:
             pass
 
+    def _reinitialize_driver(self):
+        """Quit the current driver and create a new one."""
+        logger.info("Reinitializing Chrome driver")
+        try:
+            self.driver.quit()
+        except Exception:
+            pass
+        time.sleep(2)
+        self.__init__()
+
     @classmethod
     def tuesday_string(cls, hyphenated: bool = False, abbr: bool = False) -> str:
         today = datetime.date.today()
@@ -117,24 +127,34 @@ class VangohanScraper:
             f"{'%b' if abbr else '%B'}{'-' if hyphenated else ' '}%-d"
         )
 
-    def save_menu_image(self, output_dir: str) -> bool:
+    def save_menu_image(self, output_dir: str, max_retries: int = 3) -> bool:
         logger.info("Deleting an existing menu image")
         menu_img = pathlib.Path(output_dir, "menu.png")
         menu_img.unlink(missing_ok=True)
-        logger.info("fetching menu image")
-        self.driver.get(self.VANGOHAN_URL)
-        if self._fetch_menu_image(" Menu", menu_img):
-            return True
-        elif self._fetch_menu_image(
-            VangohanScraper.tuesday_string(abbr=False), menu_img
-        ):
-            return True
-        elif self._fetch_menu_image(
-            VangohanScraper.tuesday_string(abbr=True), menu_img
-        ):
-            return True
-        else:
-            return False
+        for attempt in range(max_retries):
+            try:
+                logger.info(f"fetching menu image (attempt {attempt + 1}/{max_retries})")
+                self.driver.get(self.VANGOHAN_URL)
+                if self._fetch_menu_image(" Menu", menu_img):
+                    return True
+                elif self._fetch_menu_image(
+                    VangohanScraper.tuesday_string(abbr=False), menu_img
+                ):
+                    return True
+                elif self._fetch_menu_image(
+                    VangohanScraper.tuesday_string(abbr=True), menu_img
+                ):
+                    return True
+                else:
+                    return False
+            except WebDriverException as e:
+                logger.warning(f"WebDriverException on attempt {attempt + 1}: {e}")
+                if attempt < max_retries - 1:
+                    self._reinitialize_driver()
+                else:
+                    logger.error(f"Failed to fetch menu image after {max_retries} attempts")
+                    return False
+        return False
 
     def _fetch_menu_image(self, target_str: str, menu_img: pathlib.Path) -> bool:
         logger.info(f"{target_str=}")
@@ -268,6 +288,8 @@ class VangohanScraper:
             except (WebDriverException, TimeoutException) as e:
                 logger.warning(f"Error fetching {url} on attempt {attempt + 1}: {e}")
                 if attempt < max_retries - 1:
+                    if isinstance(e, WebDriverException) and not isinstance(e, TimeoutException):
+                        self._reinitialize_driver()
                     time.sleep(1)
                 else:
                     logger.error(f"Failed to fetch {url} after {max_retries} attempts")


### PR DESCRIPTION
## Summary
- Add `nick-fields/retry@v3` to workflow with 3 attempts and 30s wait between retries for each script invocation (Japanese/English split into separate steps)
- Add `timeout-minutes: 30` to the job to prevent indefinite hangs
- Implement `_reinitialize_driver()` method that was referenced but never defined (latent bug)
- Add retry with driver reinitialization in `save_menu_image()` to handle the `ReadTimeoutError` seen in [run #23813158821](https://github.com/chezou/vangohan-pdf/actions/runs/23813158821/attempts/2)
- Reinitialize driver on `WebDriverException` in `_fetch_single_recipe()` instead of retrying with a broken driver

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify it completes successfully
- [ ] Verify retry behavior by checking logs show attempt counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)