### PR TITLE
Fix 429 rate limit crash and improve Cloudflare detection

### DIFF
--- a/fetch_vangohan.py
+++ b/fetch_vangohan.py
@@ -98,12 +98,14 @@ class VangohanScraper:
             pass
 
     def _wait_for_cloudflare(self, timeout: int = 120):
+        time.sleep(2)
         if self.driver.title == "Just a moment...":
             logger.info("Cloudflare challenge detected, waiting for Turnstile to solve...")
             WebDriverWait(self.driver, timeout).until(
                 lambda d: d.title != "Just a moment..."
             )
             logger.info(f"Cloudflare challenge passed, page title: {self.driver.title}")
+            time.sleep(2)
 
     def _reinitialize_driver(self):
         logger.info("Reinitializing Chrome driver")
@@ -179,12 +181,16 @@ class VangohanScraper:
             )
             src = img.get_attribute("src")
             r = httpx.get(src, follow_redirects=True)
+            r.raise_for_status()
             i = Image.open(BytesIO(r.content))
             i.save(menu_img)
 
             return True
         except TimeoutException:
             logger.error(f"TimeoutException to fetch menu image for {target_str}")
+            return False
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error fetching menu image: {e.response.status_code}")
             return False
 
     def fetch_recipes(self) -> List[str]:


### PR DESCRIPTION
## Summary
- **429 Too Many Requests クラッシュ修正**: メニュー画像ダウンロード時にNotionが429を返すと、非画像レスポンスを`Image.open()`に渡して`PIL.UnidentifiedImageError`で落ちていた。`raise_for_status()`チェックと`httpx.HTTPStatusError`のキャッチを追加。
- **Cloudflare検出タイミング改善**: `driver.get()`直後はページタイトルがまだセットされていないことがあり、Cloudflareチャレンジを検出できなかった。タイトルチェック前に2秒の待機を追加。

## Root Cause
GHA上で日本語版→英語版を連続実行すると、英語版実行時にNotionのレート制限(429)に引っかかる。また、Cloudflareチャレンジページの検出がレース条件で失敗するケースがあった。

## Test plan
- [ ] GHAのスケジュール実行で日本語・英語両方が成功すること
- [ ] 429レスポンス時にクラッシュせず`image_exist=False`で続行すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16P1PCCNERP4vFPA5pnVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R16P1PCCNERP4vFPA5pnVZ)_